### PR TITLE
Add deployment workflow and auto DB creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_KEY }}
+          port: ${{ secrets.VPS_PORT || '22' }}
+          script: |
+            cd ${{ secrets.VPS_PATH }}
+            git pull
+            rm -f db.sqlite
+            sudo systemctl restart invevent-api
+            sudo systemctl restart invevent-bot
+

--- a/README.md
+++ b/README.md
@@ -37,3 +37,22 @@
 - `templates/webapp.html`  Jinja2 template with Leaflet.js
 - `static/`  contains CSS and JS (Leaflet)
 
+## Deploying to a VPS
+
+The repository includes a workflow `.github/workflows/deploy.yml` that deploys
+the latest commit to your server.  The workflow connects to your VPS via SSH,
+pulls the repository, removes `db.sqlite`, and restarts the systemd services
+`invevent-api` and `invevent-bot`.
+
+### Setup
+
+1. On your VPS clone this repository and create two systemd services named
+   `invevent-api` and `invevent-bot` that start the FastAPI app and the bot.
+2. Add the following repository secrets on GitHub:
+   - `VPS_HOST` – server hostname or IP.
+   - `VPS_USER` – SSH user.
+   - `VPS_KEY` – private SSH key for the user.
+   - `VPS_PATH` – path to the project directory on the server.
+   - `VPS_PORT` – SSH port (optional, defaults to 22).
+3. Push to the `main` branch to trigger the workflow and deploy.
+

--- a/invevent/bot/main.py
+++ b/invevent/bot/main.py
@@ -5,7 +5,7 @@ from aiogram.types import WebAppInfo, KeyboardButton, ReplyKeyboardMarkup
 from aiogram.filters import Command
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
-from invevent.models import User
+from invevent.models import User, ensure_db
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -14,6 +14,7 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 WEBAPP_URL = os.getenv("WEBAPP_URL", "https://your.domain/webapp")
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite")
+ensure_db()  # create DB if it doesn't exist
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine)
 

--- a/invevent/models.py
+++ b/invevent/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime, Text, ForeignKey, BigInteger
 from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.engine.url import make_url
 import os
 
 Base = declarative_base()
@@ -40,5 +41,16 @@ def init_db():
     engine = create_engine(DATABASE_URL, echo=True)
     Base.metadata.create_all(engine)
 
+def ensure_db():
+    """Create the database if it does not exist."""
+    url = make_url(DATABASE_URL)
+    if url.drivername == "sqlite":
+        db_path = url.database
+        if db_path and not os.path.exists(db_path):
+            init_db()
+    else:
+        # For other engines, create tables if they do not exist
+        init_db()
+
 if __name__ == "__main__":
-    init_db()
+    ensure_db()

--- a/invevent/web/main.py
+++ b/invevent/web/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from invevent.models import Event
+from invevent.models import Event, ensure_db
 
 from dotenv import load_dotenv
 
@@ -15,6 +15,7 @@ load_dotenv()
 
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite")
+ensure_db()  # create DB if it doesn't exist
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine)
 BASE_DIR = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- ensure sqlite database is created automatically
- add GitHub Actions workflow to deploy to VPS and restart services
- document how to use the new deploy workflow

## Testing
- `python -m pytest -q`
- `python -m invevent.models`

------
https://chatgpt.com/codex/tasks/task_e_684e7ed5f188833294d41218110a9378